### PR TITLE
upgrade gke initialClusterVersion to 1.17 as 1.16 is no more available

### DIFF
--- a/cluster/gke/composition.yaml
+++ b/cluster/gke/composition.yaml
@@ -15,7 +15,7 @@ spec:
         kind: GKECluster
         spec:
           forProvider:
-            initialClusterVersion: "1.16"
+            initialClusterVersion: "1.17"
             location: us-west2
             masterAuth:
               # setting this master auth user name enables basic auth so that a client (e.g.,


### PR DESCRIPTION
Fixes https://github.com/upbound/platform-ref-gcp/issues/5

This PR upgrade the GKE `initialClusterVersion` to 1.17 as 1.16 is no more available.