### PR TITLE
update gke to 1.18 and disable private nodes

### DIFF
--- a/cluster/gke/composition.yaml
+++ b/cluster/gke/composition.yaml
@@ -27,8 +27,6 @@ spec:
               useIpAliases: true
               clusterSecondaryRangeName: pods
               servicesSecondaryRangeName: services
-            privateClusterConfig:
-              enablePrivateNodes: false
             networkConfig:
               enableIntraNodeVisibility: true
             loggingService: logging.googleapis.com/kubernetes


### PR DESCRIPTION
Signed-off-by: Steven Borrelli <steve@borrelli.org>

Fixes #5 and #7

Turns off private nodes in GKE 

## Testing

I created the Network and Cluster from the `examples/` directory after manually adding the new XRDs to the clusters:

```
✗ kubectl get managed
NAME                                                                          READY   SYNCED   STATE     ENDPOINT       LOCATION   AGE
gkecluster.container.gcp.crossplane.io/platform-ref-gcp-cluster-dbmgd-mqbd7   True    False    RUNNING   34.94.149.83   us-west2   112m

NAME                                                                        READY   SYNCED   STATE     CLUSTER-REF                            AGE
nodepool.container.gcp.crossplane.io/platform-ref-gcp-cluster-dbmgd-r9r92   True    True     RUNNING   platform-ref-gcp-cluster-dbmgd-mqbd7   112m
```

```
✗ kubectl get services.gcp.platformref.crossplane.io  platform-ref-gcp-cluster-dbmgd-td9rx
NAME                                   READY   COMPOSITION                              AGE
platform-ref-gcp-cluster-dbmgd-td9rx   True    services.gcp.platformref.crossplane.io   114m
```

## Cluster Validation

Output shows that the Docker images provisioned from the Helm provider can be pulled into cluster nodes:

```
✗ kubectl get all -n operators
NAME                                                                  READY   STATUS    RESTARTS   AGE
pod/alertmanager-platform-ref-gcp-cluster-d-alertmanager-0            2/2     Running   0          40m
pod/platform-ref-gcp-cluster-d-operator-6cfbb77b59-fs7h7              2/2     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-grafana-65c8b57958-27phc     2/2     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-kube-state-metrics-6bh9trm   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-expor2glqz   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-expor5s82t   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-expor8zm2t   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-expor9lds7   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-exporcvhb5   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-exporj6xl4   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-exporn6xz9   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-expornw7bf   1/1     Running   0          40m
pod/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-exporrsbrf   1/1     Running   0          40m
pod/prometheus-platform-ref-gcp-cluster-d-prometheus-0                3/3     Running   1          40m

NAME                                                                    TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
service/alertmanager-operated                                           ClusterIP   None             <none>        9093/TCP,9094/TCP,9094/UDP   40m
service/platform-ref-gcp-cluster-d-alertmanager                         ClusterIP   10.204.222.15    <none>        9093/TCP                     40m
service/platform-ref-gcp-cluster-d-operator                             ClusterIP   10.204.13.224    <none>        8080/TCP,443/TCP             40m
service/platform-ref-gcp-cluster-d-prometheus                           ClusterIP   10.204.4.25      <none>        9090/TCP                     40m
service/platform-ref-gcp-cluster-dbmgd-999xh-grafana                    ClusterIP   10.204.83.63     <none>        80/TCP                       40m
service/platform-ref-gcp-cluster-dbmgd-999xh-kube-state-metrics         ClusterIP   10.204.115.170   <none>        8080/TCP                     40m
service/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-exporter   ClusterIP   10.204.243.220   <none>        9100/TCP                     40m
service/prometheus-operated                                             ClusterIP   None             <none>        9090/TCP                     40m

NAME                                                                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/platform-ref-gcp-cluster-dbmgd-999xh-prometheus-node-exporter   9         9         9       9            9           <none>          40m

NAME                                                                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/platform-ref-gcp-cluster-d-operator                       1/1     1            1           40m
deployment.apps/platform-ref-gcp-cluster-dbmgd-999xh-grafana              1/1     1            1           40m
deployment.apps/platform-ref-gcp-cluster-dbmgd-999xh-kube-state-metrics   1/1     1            1           40m

NAME                                                                                 DESIRED   CURRENT   READY   AGE
replicaset.apps/platform-ref-gcp-cluster-d-operator-6cfbb77b59                       1         1         1       40m
replicaset.apps/platform-ref-gcp-cluster-dbmgd-999xh-grafana-65c8b57958              1         1         1       40m
replicaset.apps/platform-ref-gcp-cluster-dbmgd-999xh-kube-state-metrics-6bfdb4c5bb   1         1         1       40m

NAME                                                                    READY   AGE
statefulset.apps/alertmanager-platform-ref-gcp-cluster-d-alertmanager   1/1     40m
statefulset.apps/prometheus-platform-ref-gcp-cluster-d-prometheus       1/1     40m
```



