### PR TITLE
Cluster name length restriction

### DIFF
--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -105,6 +105,10 @@ spec:
               id:
                 type: string
                 description: ID of this Cluster that other objects will use to refer to it.
+                minLength: 1
+                # Maximum key length in GCP is 40 characters. We are setting a 34 character
+                # limit to accomodate the generated hash suffix ('-' + 5 chars).
+                maxLength: 34
               parameters:
                 type: object
                 description: Cluster configuration parameters.

--- a/cluster/gke/definition.yaml
+++ b/cluster/gke/definition.yaml
@@ -23,6 +23,10 @@ spec:
               id:
                 type: string
                 description: ID of this Cluster that other objects will use to refer to it.
+                minLength: 1
+                # Maximum key length in GCP is 40 characters. We are setting a 34 character
+                # limit to accomodate the generated hash suffix ('-' + 5 chars).
+                maxLength: 34
               parameters:
                 type: object
                 description: GKE configuration parameters.


### PR DESCRIPTION
Signed-off-by: Aaron Eaton <aaron@upbound.io>

### Description of your changes

GCP has a name length limit of 40 characters on GKE clusters.

Because the composed cluster name will always have a 6 character suffix ('-' + 5 char hash), we are validating that the submitted ID is 34 characters or less.

Fixes https://github.com/upbound/platform-ref-gcp/issues/9

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).

### How has this code been tested

Deployed a GKE Resource with a 60 character name and received a validation error.