### PR TITLE
Only push for linux_amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@
 PROJECT_NAME := platform-ref-gcp
 PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)
 
-PLATFORMS ?= linux_amd64 linux_arm64
+# NOTE(turkenh): we need to publish only for linux_amd64 because we are using
+# pkg controllers seems to be looking for that explicitly. Otherwise, it was failing with: 
+# cannot initialize parser backend: failed to fetch package from remote: no child with 
+# platform linux/amd64 in index xpkg.upbound.io/upbound/platform-ref-gcp:v0.2.0-rc.0.4.gdac9a0c
+PLATFORMS ?= linux_amd64
 include build/makelib/common.mk
 
 # ====================================================================================


### PR DESCRIPTION
### Description of your changes

we need to publish only for linux_amd64 because we are using pkg controllers seems to be looking for that explicitly. Otherwise, it was failing with: 

> cannot initialize parser backend: failed to fetch package from remote: no child with 
> platform linux/amd64 in index xpkg.upbound.io/upbound/platform-ref-gcp:v0.2.0-rc.0.4.gdac9a0c

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested with platform-ref-aws and platform-ref-azure.