### PR TITLE
E2E - CI improvements and wait for provider gcp before applying providerconfig

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["**.md", "**.png", "**.jpg"]'
-          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "push", "issue_comment"]'
 
   e2e:
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,3 +53,22 @@ jobs:
         env:
           UPTEST_GCP_PROJECT: ${{ secrets.UPTEST_GCP_PROJECT }}
           UPTEST_GCP_CREDS: ${{ secrets.UPTEST_GCP_CREDS }}
+
+      - name: Collect Control Plane Dump
+        if: always()
+        run: |
+          export CONTROLPLANE_DUMP_DIRECTORY=./_output/controlplane-dump
+          make controlplane.dump
+
+      - name: Upload Control Plane Dump
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cluster-dump-${{ needs.get-example-list.outputs.provider_name }}
+          path: ./_output/controlplane-dump
+
+      - name: Cleanup
+        if: always()
+        run: |
+          eval $(make --no-print-directory build.vars)
+          ${KUBECTL} delete managed --all

--- a/Makefile
+++ b/Makefile
@@ -58,4 +58,12 @@ uptest: build $(UPTEST) $(KUBECTL) $(KUTTL) local.xpkg.deploy.configuration.$(PR
 	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e examples/cluster-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
 	@$(OK) running automated tests
 
+#TODO(turkenh): move to build submodule
+CONTROLPLANE_DUMP_DIRECTORY ?= $(OUTPUT_DIR)/controlplane-dump
+controlplane.dump: $(KUBECTL)
+	@mkdir -p ${DUMP_DIRECTORY}
+	@$(KUBECTL) cluster-info dump --output-directory ${DUMP_DIRECTORY} --all-namespaces || true
+	@$(KUBECTL) get managed -o yaml > ${DUMP_DIRECTORY}/managed.yaml || true
+	@cat /tmp/automated-tests/case/*.yaml > ${DUMP_DIRECTORY}/kuttl-inputs.yaml
+
 e2e: controlplane.up uptest

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -12,6 +12,7 @@ echo "Creating cloud credential secret"
 ${KUBECTL} -n upbound-system create secret generic gcp-creds --from-literal=credentials="${UPTEST_GCP_CREDS}" \
     --dry-run=client -o yaml | ${KUBECTL} apply -f -
 
+${KUBECTL} wait crd providerconfigs.gcp.upbound.io --for=condition=established
 echo "Creating a default provider config"
 cat <<EOF | ${KUBECTL} apply -f -
 apiVersion: gcp.upbound.io/v1beta1


### PR DESCRIPTION
### Description of your changes

This PR includes changes to improve running e2e in CI:

- Wait until providerconfig CRD before applying it.
- Collect/Dump logs
- Run cleanup
- Do not skip with no op if a new comment added.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

I believe I need to merge this PR to test with CI since workflow changes not reflected before merge.
