### PR TITLE
More waits for CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,7 +2,6 @@ name: End to End Test
 
 on:
   workflow_dispatch: {}
-  pull_request: {}
   issue_comment:
     types: [created]
 
@@ -30,14 +29,6 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Fetch History
-        run: git fetch --prune --unshallow
-
       - uses: khan/pull-request-comment-trigger@v1.1.0
         if: github.event_name != 'workflow_dispatch'
         id: check
@@ -47,6 +38,22 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Checkout PR
+        if: github.event_name != 'workflow_dispatch'
+        id: checkout-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+
       - name: End to end
         run: make e2e
         if: steps.check.outputs.triggered == 'true' || github.event_name == 'workflow_dispatch'
@@ -55,20 +62,20 @@ jobs:
           UPTEST_GCP_CREDS: ${{ secrets.UPTEST_GCP_CREDS }}
 
       - name: Collect Control Plane Dump
-        if: always()
+        if: steps.check.outputs.triggered == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           export CONTROLPLANE_DUMP_DIRECTORY=./_output/controlplane-dump
           make controlplane.dump
 
       - name: Upload Control Plane Dump
-        if: always()
+        if: steps.check.outputs.triggered == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v3
         with:
           name: control-plane-dump
           path: ./_output/controlplane-dump
 
       - name: Cleanup
-        if: always()
+        if: steps.check.outputs.triggered == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           eval $(make --no-print-directory build.vars)
           ${KUBECTL} delete managed --all

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,8 +2,7 @@ name: End to End Test
 
 on:
   workflow_dispatch: {}
-  pull_request:
-    types: [opened]
+  pull_request: {}
   issue_comment:
     types: [created]
 

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -15,7 +15,10 @@ ${KUBECTL} -n upbound-system create secret generic gcp-creds --from-literal=cred
 echo "Waiting until provider-gcp is healthy..."
 ${KUBECTL} wait provider.pkg upbound-provider-gcp --for condition=Healthy --timeout 5m
 
-echo "Creating a default provider config"
+echo_step "Waiting for all pods to come online"
+"${KUBECTL}" -n upbound-system wait --for=condition=Available deployment --all --timeout=5m
+
+echo "Creating a default provider config..."
 cat <<EOF | ${KUBECTL} apply -f -
 apiVersion: gcp.upbound.io/v1beta1
 kind: ProviderConfig


### PR DESCRIPTION
### Description of your changes

It looks like CI is suffering from low resources resulting different behaviour compared to local dev. Adding more checks before attempting to start installing CRs.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Test after merge.