### PR TITLE
Integrate App claim with Mysql backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,15 @@ build.init: $(UP)
 
 # This target requires the following environment variables to be set:
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat gcp-sa.json)
+SKIP_DELETE ?=
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/cluster-claim.yaml,examples/postgres-claim.yaml --setup-script=test/setup.sh --default-timeout=3600 || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/cluster-claim.yaml,examples/postgres-claim.yaml,examples/mysql-claim.yaml,examples/app-claim.yaml --setup-script=test/setup.sh --default-timeout=3600 $(SKIP_DELETE) || $(FAIL)
 	@$(OK) running automated tests
 
 # This target requires the following environment variables to be set:
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat gcp-sa.json)
+# Use `make e2e SKIP_DELETE=--skip-delete` to skip deletion of resources created during the test.
 e2e: build controlplane.up local.xpkg.deploy.configuration.$(PROJECT_NAME) uptest
 
 render:

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -38,7 +38,7 @@ spec:
       version: "v0.5.0"
     - configuration: xpkg.upbound.io/upbound/configuration-gcp-database
       # renovate: datasource=github-releases depName=upbound/configuration-gcp-database
-      version: "v0.4.0"
+      version: "v0.5.0"
     - configuration: xpkg.upbound.io/upbound/configuration-app
       # renovate: datasource=github-releases depName=upbound/configuration-app
       version: "v0.5.0"

--- a/examples/app-claim.yaml
+++ b/examples/app-claim.yaml
@@ -11,6 +11,6 @@ spec:
     providerConfigName: platform-ref-gcp
     passwordSecretRef:
       namespace: default
-      name: platform-ref-gcp-db-conn-mariadb
+      name: platform-ref-gcp-database-mysql-conn
   writeConnectionSecretToRef:
     name: platform-ref-gcp-ghost-conn

--- a/examples/cluster-claim.yaml
+++ b/examples/cluster-claim.yaml
@@ -10,7 +10,7 @@ spec:
     region: us-west2
     version: latest
     nodes:
-      count: 3
+      count: 1
       instanceType: n1-standard-4
     gitops:
       git:

--- a/examples/mysql-claim.yaml
+++ b/examples/mysql-claim.yaml
@@ -1,0 +1,28 @@
+apiVersion: gcp.platform.upbound.io/v1alpha1
+kind: SQLInstance
+metadata:
+  name: platform-ref-gcp-database-mysql
+  namespace: default
+spec:
+  parameters:
+    engine: mysql
+    engineVersion: "8_0"
+    region: us-west2
+    storageGB: 10
+    passwordSecretRef:
+      namespace: default
+      name: mysqlsecret
+      key: password
+    networkRef:
+      id: platform-ref-gcp
+  writeConnectionSecretToRef:
+    name: platform-ref-gcp-database-mysql-conn
+---
+apiVersion: v1
+data:
+  password: dXBiMHVuZHIwY2s1ITMxMzM3
+kind: Secret
+metadata:
+  name: mysqlsecret
+  namespace: default
+type: Opaque


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Use the recent version of configuration-gcp-database that provides database configuration and connection ready for consumption by App Claim
* Add SKIP_DELETE
* Extend uptest test run with Mysql Datatbase and App Claim

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
make e2e SKIP_DELETE=--skip-delete
...
--- PASS: kuttl (1014.22s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (1013.70s)
PASS
00:24:43 [ OK ] running automated tests
```

```
k get claim
NAME                                                                  SYNCED   READY   CONNECTION-SECRET                      AGE
sqlinstance.gcp.platform.upbound.io/platform-ref-gcp-database-mysql   True     True    platform-ref-gcp-database-mysql-conn   18m
sqlinstance.gcp.platform.upbound.io/platform-ref-gcp-db-postgres      True     True    platform-ref-gcp-db-conn-postgres      18m

NAME                                                  SYNCED   READY   CONNECTION-SECRET             AGE
cluster.gcp.platformref.upbound.io/platform-ref-gcp   True     True    platform-ref-gcp-kubeconfig   18m

NAME                                             SYNCED   READY   CONNECTION-SECRET             AGE
app.platform.upbound.io/platform-ref-gcp-ghost   True     True    platform-ref-gcp-ghost-conn   18m
```

On the workload GKE cluster:

```
k -n ghost get pod
NAME                                                  READY   STATUS    RESTARTS   AGE
platform-ref-gcp-ghost-828gj-5nnd5-58dd577996-hjxzt   1/1     Running   0          5m21s

k -n ghost logs -f platform-ref-gcp-ghost-828gj-5nnd5-58dd577996-hjxzt
ghost 22:24:17.50
ghost 22:24:17.50 Welcome to the Bitnami ghost container
ghost 22:24:17.50 Subscribe to project updates by watching https://github.com/bitnami/containers
ghost 22:24:17.50 Submit issues and feature requests at https://github.com/bitnami/containers/issues
ghost 22:24:17.50
ghost 22:24:17.51 INFO  ==> Configuring libnss_wrapper
ghost 22:24:17.54 INFO  ==> Validating settings in MYSQL_CLIENT_* env vars
ghost 22:24:17.57 WARN  ==> You set the environment variable ALLOW_EMPTY_PASSWORD=yes. For safety reasons, do not use this flag in a production environment.
ghost 22:24:17.58 INFO  ==> Ensuring Ghost directories exist
ghost 22:24:17.59 INFO  ==> Trying to connect to the database server
ghost 22:24:17.62 INFO  ==> Configuring database
ghost 22:24:17.67 INFO  ==> Setting up Ghost
ghost 22:24:18.78 INFO  ==> Configuring Ghost URL to http://upboundrocks.cloud/
ghost 22:24:18.83 INFO  ==> Passing admin user creation wizard
ghost 22:24:18.84 INFO  ==> Starting Ghost in background
ghost 22:24:41.21 INFO  ==> Stopping Ghost
ghost 22:24:42.11 INFO  ==> Persisting Ghost installation
ghost 22:24:42.21 INFO  ==> ** Ghost setup finished! **

ghost 22:24:42.24 INFO  ==> ** Starting Ghost **
```
