### PR TITLE
use gcp in trace command instead of aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ To get nice representation of the Claim deployment status you can use
 [crossplane beta trace](https://docs.crossplane.io/latest/cli/command-reference/#beta-trace) command
 
 ```console
-crossplane beta trace cluster.aws.platformref.upbound.io/platform-ref-aws
+crossplane beta trace cluster.gcp.platformref.upbound.io/platform-ref-gcp
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have: updated the example trace command to refer to gcp instead of aws

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually previewed readme markdown.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
