### PR TITLE
Migrate platform-ref-gcp to Crossplane v2

### DIFF
--- a/apis/cluster/composition.yaml
+++ b/apis/cluster/composition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xclusters.gcp.platformref.upbound.io
+  name: clusters.gcp.platformref.upbound.io
 spec:
   compositeTypeRef:
     apiVersion: gcp.platformref.upbound.io/v1alpha1
-    kind: XCluster
+    kind: Cluster
   mode: Pipeline
   pipeline:
   - functionRef:

--- a/apis/cluster/definition.yaml
+++ b/apis/cluster/definition.yaml
@@ -1,18 +1,14 @@
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
-  name: xclusters.gcp.platformref.upbound.io
+  name: clusters.gcp.platformref.upbound.io
 spec:
+  scope: Namespaced
   defaultCompositeDeletePolicy: Foreground
   group: gcp.platformref.upbound.io
   names:
-    kind: XCluster
-    plural: xclusters
-  claimNames:
     kind: Cluster
     plural: clusters
-  connectionSecretKeys:
-    - kubeconfig
   versions:
     - name: v1alpha1
       served: true

--- a/examples/app-claim.yaml
+++ b/examples/app-claim.yaml
@@ -6,13 +6,14 @@ metadata:
   labels:
     platform.upbound.io/deletion-ordering: enabled
 spec:
-  compositeDeletePolicy: Foreground
   parameters:
     providerConfigName: platform-ref-gcp-devex
     helm:
+      chart:
+        name: ghost
+        repo: "oci://registry-1.docker.io/bitnamicharts"
+        version: "25.0.4"
       wait: false
     passwordSecretRef:
       namespace: default
       name: platform-ref-gcp-database-mysql-conn
-  writeConnectionSecretToRef:
-    name: platform-ref-gcp-ghost-conn

--- a/examples/cluster-claim.yaml
+++ b/examples/cluster-claim.yaml
@@ -4,7 +4,6 @@ metadata:
   name: platform-ref-gcp
   namespace: default
 spec:
-  compositeDeletePolicy: Foreground
   parameters:
     id: platform-ref-gcp-devex
     region: us-west2
@@ -21,5 +20,3 @@ spec:
           # refs/pull/420/head
           # refs/merge-requests/1/head
           name: refs/heads/main
-  writeConnectionSecretToRef:
-    name: platform-ref-gcp-kubeconfig

--- a/examples/cluster-xr.yaml
+++ b/examples/cluster-xr.yaml
@@ -1,7 +1,8 @@
 apiVersion: gcp.platformref.upbound.io/v1alpha1
-kind: XCluster
+kind: Cluster
 metadata:
   name: platform-ref-gcp
+  namespace: default
   uid: test-uid-12345
 spec:
   parameters:
@@ -28,6 +29,3 @@ spec:
         timeout: 60s
         ref:
           name: refs/heads/main
-  writeConnectionSecretToRef:
-    name: platform-ref-gcp-kubeconfig
-    namespace: default

--- a/examples/mysql-claim.yaml
+++ b/examples/mysql-claim.yaml
@@ -15,8 +15,6 @@ spec:
       key: password
     networkRef:
       id: platform-ref-gcp-devex
-  writeConnectionSecretToRef:
-    name: platform-ref-gcp-database-mysql-conn
 ---
 apiVersion: v1
 data:

--- a/examples/postgres-claim.yaml
+++ b/examples/postgres-claim.yaml
@@ -15,8 +15,6 @@ spec:
       key: password
     networkRef:
       id: platform-ref-gcp
-  writeConnectionSecretToRef:
-    name: platform-ref-gcp-db-conn-postgres
 ---
 apiVersion: v1
 data:

--- a/functions/cluster/main.k
+++ b/functions/cluster/main.k
@@ -2,7 +2,7 @@
 import models.io.upbound.platform.gcp.v1alpha1 as gcpplatform
 import models.io.upbound.platform.observe.v1alpha1 as observeplatform
 import models.io.upbound.platform.gitops.v1alpha1 as gitopsplatform
-import models.io.crossplane.apiextensions.v1alpha1 as crossplaneapiextensionsv1alpha1
+import models.io.crossplane.protection.v1beta1 as crossplaneprotectionv1beta1
 
 oxr = option("params").oxr
 _ocds = option("params").ocds
@@ -20,7 +20,7 @@ _metadata = lambda name: str -> any {
 params = oxr.spec.parameters
 _id = params.id
 _region = params.region
-_deletion_policy = params.deletionPolicy
+_deletion_policy = params.deletionPolicy  # Kept for backward compatibility, converted to managementPolicies
 _provider_config_name = params.providerConfigName
 _version = params.version
 _nodes_count = params.nodes.count
@@ -28,11 +28,10 @@ _nodes_instance_type = params.nodes.instanceType
 _operators = params.operators
 _gitops = params.gitops
 
-# XR connection secret details for XGKE
-_xr_uid = oxr.metadata.uid
-_connection_secret_namespace = _dxr.spec?.writeConnectionSecretToRef?.namespace or "upbound-system"
+# Convert deletionPolicy to managementPolicies for v2
+_management_policies = ["Create", "Observe", "Update", "LateInitialize"] if _deletion_policy == "Orphan" else ["*"]
 
-# Check if XGKE is ready before creating any dependent resources (they all need cluster to be ready)
+# Check if GKE is ready before creating any dependent resources (they all need cluster to be ready)
 _gkeResource = None
 if _ocds and "composite-cluster-gke" in _ocds:
     _gkeResource = _ocds["composite-cluster-gke"]
@@ -44,23 +43,23 @@ _ossExists = "composite-observability-oss" in _ocds if _ocds else False
 _fluxExists = "composite-gitops-flux" in _ocds if _ocds else False
 
 _items = [
-    # Connection details are automatically propagated from XGKE since it has kubeconfig in its connection secrets
+    # Connection details are automatically propagated from GKE since it has kubeconfig in its connection secrets
 
-    # XNetwork resource
-    gcpplatform.XNetwork {
+    # Network resource
+    gcpplatform.Network {
         metadata = _metadata("composite-network-gcp")
         spec = {
             parameters = {
                 id = _id
                 region = _region
-                deletionPolicy = _deletion_policy
+                managementPolicies = _management_policies
                 providerConfigName = _provider_config_name
             }
         }
     },
 
-    # XGKE resource with connection details
-    gcpplatform.XGKE {
+    # GKE resource (connection details are automatically propagated to parent XR)
+    gcpplatform.GKE {
         metadata = _metadata("composite-cluster-gke") | {
             labels = {
                 "xgke.gcp.platform.upbound.io/cluster-id" = _id
@@ -73,7 +72,7 @@ _items = [
             parameters = {
                 id = _id
                 region = _region
-                deletionPolicy = _deletion_policy
+                managementPolicies = _management_policies
                 providerConfigName = _provider_config_name
                 version = _version
                 nodes = {
@@ -81,21 +80,17 @@ _items = [
                     instanceType = _nodes_instance_type
                 }
             }
-            writeConnectionSecretToRef = {
-                name = "{}-gke".format(_xr_uid)
-                namespace = _connection_secret_namespace
-            }
         }
     },
 
-    # XOss observability resource - only create when XGKE is ready (needs cluster to be available)
+    # Oss observability resource - only create when GKE is ready (needs cluster to be available)
     # Also create if it already exists to prevent uninstalling
     if _isGkeReady or _ossExists:
-        observeplatform.XOss {
+        observeplatform.Oss {
             metadata = _metadata("composite-observability-oss")
             spec = {
                 parameters = {
-                    deletionPolicy = _deletion_policy
+                    managementPolicies = _management_policies
                     id = _id
                     operators = {
                         prometheus = _operators.prometheus
@@ -104,14 +99,14 @@ _items = [
             }
         }
 
-    # XFlux GitOps resource - only create when XGKE is ready (needs cluster kubeconfig)
+    # Flux GitOps resource - only create when GKE is ready (needs cluster kubeconfig)
     # Also create if it already exists to prevent uninstalling
     if _isGkeReady or _fluxExists:
-        gitopsplatform.XFlux {
+        gitopsplatform.Flux {
             metadata = _metadata("composite-gitops-flux")
             spec = {
                 parameters = {
-                    deletionPolicy = _deletion_policy
+                    managementPolicies = _management_policies
                     providerConfigName = _id
                     operators = {
                         flux = _operators.flux
@@ -123,22 +118,23 @@ _items = [
         }
 
     # Usage resources for dependency management (typed objects)
-    crossplaneapiextensionsv1alpha1.Usage {
-        metadata = _metadata("usage-xgke-by-xflux") | {
+    crossplaneprotectionv1beta1.Usage {
+        metadata = _metadata("usage-gke-by-flux") | {
             name = "{}-gke-by-flux".format(_id)
+            namespace = oxr.metadata.namespace
         }
         spec = {
             replayDeletion = True
             by = {
                 apiVersion = "gitops.platform.upbound.io/v1alpha1"
-                kind = "XFlux"
+                kind = "Flux"
                 resourceSelector = {
                     matchControllerRef = True
                 }
             }
             of = {
                 apiVersion = "gcp.platform.upbound.io/v1alpha1"
-                kind = "XGKE"
+                kind = "GKE"
                 resourceSelector = {
                     matchControllerRef = True
                 }
@@ -146,22 +142,23 @@ _items = [
         }
     }
 
-    crossplaneapiextensionsv1alpha1.Usage {
-        metadata = _metadata("usage-xgke-by-xoss") | {
+    crossplaneprotectionv1beta1.Usage {
+        metadata = _metadata("usage-gke-by-oss") | {
             name = "{}-gke-by-oss".format(_id)
+            namespace = oxr.metadata.namespace
         }
         spec = {
             replayDeletion = True
             by = {
                 apiVersion = "observe.platform.upbound.io/v1alpha1"
-                kind = "XOss"
+                kind = "Oss"
                 resourceSelector = {
                     matchControllerRef = True
                 }
             }
             of = {
                 apiVersion = "gcp.platform.upbound.io/v1alpha1"
-                kind = "XGKE"
+                kind = "GKE"
                 resourceSelector = {
                     matchControllerRef = True
                 }
@@ -169,9 +166,10 @@ _items = [
         }
     }
 
-    crossplaneapiextensionsv1alpha1.Usage {
-        metadata = _metadata("usage-xgke-by-arbitrary-labeled-release") | {
+    crossplaneprotectionv1beta1.Usage {
+        metadata = _metadata("usage-gke-by-arbitrary-labeled-release") | {
             name = "{}-gke-by-labeled-release".format(_id)
+            namespace = oxr.metadata.namespace
             annotations = {
                 "krm.kcl.dev/ready" = "True"
             }
@@ -189,7 +187,7 @@ _items = [
             }
             of = {
                 apiVersion = "gcp.platform.upbound.io/v1alpha1"
-                kind = "XGKE"
+                kind = "GKE"
                 resourceSelector = {
                     matchControllerRef = True
                 }
@@ -197,17 +195,6 @@ _items = [
         }
     }
 
-    # Forward connection details from XGKE
-    {
-        apiVersion = "meta.krm.kcl.dev/v1alpha1"
-        kind = "CompositeConnectionDetails"
-        if _gkeResource:
-            data = {
-                kubeconfig = _gkeResource.ConnectionDetails.kubeconfig
-            }
-        else:
-            data = {}
-    }
 ]
 
 items = _items

--- a/tests/e2etest-cluster/main.k
+++ b/tests/e2etest-cluster/main.k
@@ -65,13 +65,14 @@ _items = [
                         region = "us-west2"
                         storageGB = 10
                         passwordSecretRef = {
-                            namespace = "default"
                             name = "mysqlsecret"
                             key = "password"
                         }
                         networkRef = {
                             id = "e2e-platform-ref-gcp"
                         }
+                        managementPolicies = ["*"]
+                        providerConfigName = "default"
                     }
                 }
                 # App (Ghost)

--- a/tests/e2etest-cluster/main.k
+++ b/tests/e2etest-cluster/main.k
@@ -1,9 +1,10 @@
 
 import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
+import models.io.k8s.api.core.v1 as corev1
 import models.io.upbound.platformref.gcp.v1alpha1 as platformrefgcpv1alpha1
-import models.io.upbound.gcp.v1beta1 as gcpv1beta1
+import models.io.upbound.platform.gcp.v1alpha1 as platformgcpv1alpha1
 import models.io.upbound.platform.v1alpha1 as platformv1alpha1
-import models.io.crossplane.apiextensions.v1alpha1 as crossplaneapiextensionsv1alpha1
+import models.io.upbound.gcpm.v1beta1 as gcpmv1beta1
 
 _items = [
     metav1alpha1.E2ETest{
@@ -12,113 +13,100 @@ _items = [
             crossplane.autoUpgrade.channel = "Rapid"
             defaultConditions = ["Ready"]
             manifests = [
-                # Create XCluster (not Claim) for E2E testing
-                platformrefgcpv1alpha1.XCluster{
-                    apiVersion = "gcp.platformref.upbound.io/v1alpha1"
-                    kind = "XCluster"
+                # Cluster XR
+                platformrefgcpv1alpha1.Cluster{
                     metadata = {
                         name = "platform-ref-gcp-cluster"
+                        namespace = "default"
                     }
-                    spec = {
-                        parameters = {
-                            id = "e2e-platform-ref-gcp"
-                            region = "us-west2"
-                            version = "latest"
-                            deletionPolicy = "Delete"
-                            providerConfigName = "default"
-                            nodes = {
-                                count = 1
-                                instanceType = "n1-standard-4"
+                    spec.parameters = {
+                        id = "e2e-platform-ref-gcp"
+                        region = "us-west2"
+                        version = "latest"
+                        deletionPolicy = "Delete"
+                        providerConfigName = "default"
+                        nodes = {
+                            count = 1
+                            instanceType = "n1-standard-4"
+                        }
+                        operators = {
+                            flux = {
+                                version = "2.10.6"
                             }
-                            operators = {
-                                flux = {
-                                    version = "2.10.6"
-                                }
-                                "flux-sync" = {
-                                    version = "1.7.2"
-                                }
-                                prometheus = {
-                                    version = "52.1.0"
-                                }
+                            "flux-sync" = {
+                                version = "1.7.2"
                             }
-                            gitops = {
-                                git = {
-                                    url = "https://github.com/upbound/platform-ref-gcp/"
-                                    path = "/"
-                                    interval = "5m0s"
-                                    timeout = "60s"
-                                    ref = {
-                                        name = "refs/heads/main"
-                                    }
-                                }
+                            prometheus = {
+                                version = "52.1.0"
                             }
                         }
-                        writeConnectionSecretToRef = {
-                            name = "platform-ref-gcp-cluster-kubeconfig"
-                            namespace = "upbound-system"
+                        gitops = {
+                            git = {
+                                url = "https://github.com/upbound/platform-ref-gcp/"
+                                path = "/"
+                                interval = "5m0s"
+                                timeout = "60s"
+                                ref = {
+                                    name = "refs/heads/main"
+                                }
+                            }
                         }
                     }
                 }
-                # Create XSQLInstance (MySQL database) for E2E testing
-                {
-                    apiVersion = "gcp.platform.upbound.io/v1alpha1"
-                    kind = "XSQLInstance"
+                # SQLInstance (MySQL)
+                platformgcpv1alpha1.SQLInstance{
                     metadata = {
                         name = "platform-ref-gcp-database-mysql-test"
+                        namespace = "default"
                     }
-                    spec = {
-                        parameters = {
-                            engine = "mysql"
-                            engineVersion = "8_0"
-                            region = "us-west2"
-                            storageGB = 10
-                            passwordSecretRef = {
-                                namespace = "upbound-system"
-                                name = "mysqlsecret"
-                                key = "password"
-                            }
-                            networkRef = {
-                                id = "e2e-platform-ref-gcp"
-                            }
+                    spec.parameters = {
+                        engine = "mysql"
+                        engineVersion = "8_0"
+                        region = "us-west2"
+                        storageGB = 10
+                        passwordSecretRef = {
+                            namespace = "default"
+                            name = "mysqlsecret"
+                            key = "password"
                         }
-                        writeConnectionSecretToRef = {
-                            name = "platform-ref-gcp-database-mysql-conn"
-                            namespace = "upbound-system"
+                        networkRef = {
+                            id = "e2e-platform-ref-gcp"
                         }
                     }
                 }
-                # Create XApp (Ghost application) for E2E testing
-                platformv1alpha1.XApp{
-                    apiVersion = "platform.upbound.io/v1alpha1"
-                    kind = "XApp"
+                # App (Ghost)
+                platformv1alpha1.App{
                     metadata = {
                         name = "platform-ref-gcp-ghost"
+                        namespace = "default"
                         labels = {
                             "platform.upbound.io/deletion-ordering" = "enabled"
                         }
                     }
-                    spec = {
-                        parameters = {
-                            providerConfigName = "e2e-platform-ref-gcp"
-                            helm = {
-                                wait = False
+                    spec.parameters = {
+                        providerConfigName = "e2e-platform-ref-gcp"
+                        helm = {
+                            chart = {
+                                name = "ghost"
+                                repo = "oci://registry-1.docker.io/bitnamicharts"
+                                version = "25.0.4"
                             }
-                            passwordSecretRef = {
-                                namespace = "upbound-system"
-                                name = "platform-ref-gcp-database-mysql-conn"
-                            }
+                            wait = False
                         }
-                        writeConnectionSecretToRef = {
-                            name = "platform-ref-gcp-ghost-conn"
-                            namespace = "upbound-system"
+                        passwordSecretRef = {
+                            namespace = "default"
+                            name = "platform-ref-gcp-database-mysql-test-connection"
                         }
                     }
                 }
             ]
             extraResources = [
-                # GCP ProviderConfig for authentication
-                gcpv1beta1.ProviderConfig{
-                    metadata.name = "default"
+                # GCP ProviderConfig (v2 provider family group)
+                gcpmv1beta1.ProviderConfig{
+                    metadata = {
+                        name = "default"
+                        namespace = "default"
+                    }
                     spec = {
                         projectID = "crossplane-playground"
                         credentials = {
@@ -132,13 +120,11 @@ _items = [
                         }
                     }
                 }
-                # MySQL password secret for database connection
-                {
-                    apiVersion = "v1"
-                    kind = "Secret"
+                # MySQL password secret
+                corev1.Secret{
                     metadata = {
                         name = "mysqlsecret"
-                        namespace = "upbound-system"
+                        namespace = "default"
                     }
                     type = "Opaque"
                     data = {

--- a/tests/test-cluster/main.k
+++ b/tests/test-cluster/main.k
@@ -4,7 +4,7 @@ import models.io.upbound.platform.gcp.v1alpha1 as gcpv1alpha1
 import models.io.upbound.platform.gitops.v1alpha1 as gitopsv1alpha1
 import models.io.upbound.platform.observe.v1alpha1 as observev1alpha1
 import models.io.upbound.platformref.gcp.v1alpha1 as platformrefgcpv1alpha1
-import models.io.crossplane.apiextensions.v1alpha1 as crossplaneapiextensionsv1alpha1
+import models.io.crossplane.protection.v1beta1 as crossplaneprotectionv1beta1
 
 _items = [
     metav1alpha1.CompositionTest{
@@ -16,8 +16,8 @@ _items = [
             timeoutSeconds = 60
             validate = False
             assertResources = [
-                # XNetwork composite resource
-                gcpv1alpha1.XNetwork{
+                # Network composite resource
+                gcpv1alpha1.Network{
                     metadata = {
                         name = "composite-network-gcp"
                         labels = {
@@ -31,13 +31,13 @@ _items = [
                         parameters = {
                             id = "platform-ref-gcp"
                             region = "us-west2"
-                            deletionPolicy = "Delete"
+                            managementPolicies = ["*"]
                             providerConfigName = "default"
                         }
                     }
                 }
-                # XGKE composite resource
-                gcpv1alpha1.XGKE{
+                # GKE composite resource
+                gcpv1alpha1.GKE{
                     metadata = {
                         name = "composite-cluster-gke"
                         labels = {
@@ -53,7 +53,7 @@ _items = [
                         parameters = {
                             id = "platform-ref-gcp"
                             region = "us-west2"
-                            deletionPolicy = "Delete"
+                            managementPolicies = ["*"]
                             providerConfigName = "default"
                             version = "latest"
                             nodes = {
@@ -61,14 +61,10 @@ _items = [
                                 instanceType = "n1-standard-4"
                             }
                         }
-                        writeConnectionSecretToRef = {
-                            name = "test-uid-12345-gke"
-                            namespace = "upbound-system"
-                        }
                     }
                 }
-                # XOss observability resource
-                observev1alpha1.XOss{
+                # Oss observability resource
+                observev1alpha1.Oss{
                     metadata = {
                         name = "composite-observability-oss"
                         labels = {
@@ -80,7 +76,7 @@ _items = [
                     }
                     spec = {
                         parameters = {
-                            deletionPolicy = "Delete"
+                            managementPolicies = ["*"]
                             id = "platform-ref-gcp"
                             operators = {
                                 prometheus = {
@@ -90,8 +86,8 @@ _items = [
                         }
                     }
                 }
-                # XFlux GitOps resource
-                gitopsv1alpha1.XFlux{
+                # Flux GitOps resource
+                gitopsv1alpha1.Flux{
                     metadata = {
                         name = "composite-gitops-flux"
                         labels = {
@@ -103,7 +99,7 @@ _items = [
                     }
                     spec = {
                         parameters = {
-                            deletionPolicy = "Delete"
+                            managementPolicies = ["*"]
                             providerConfigName = "platform-ref-gcp"
                             operators = {
                                 flux = {
@@ -128,63 +124,63 @@ _items = [
                     }
                 }
                 # Usage resources for dependency management (typed objects)
-                crossplaneapiextensionsv1alpha1.Usage{
+                crossplaneprotectionv1beta1.Usage{
                     metadata = {
                         name = "platform-ref-gcp-gke-by-flux"
                         labels = {
                             "crossplane.io/composite" = "platform-ref-gcp"
                         }
                         annotations = {
-                            "crossplane.io/composition-resource-name" = "usage-xgke-by-xflux"
+                            "crossplane.io/composition-resource-name" = "usage-gke-by-flux"
                         }
                     }
                     spec = {
                         replayDeletion = True
                         by = {
                             apiVersion = "gitops.platform.upbound.io/v1alpha1"
-                            kind = "XFlux"
+                            kind = "Flux"
                             resourceSelector = {
                                 matchControllerRef = True
                             }
                         }
                         of = {
                             apiVersion = "gcp.platform.upbound.io/v1alpha1"
-                            kind = "XGKE"
+                            kind = "GKE"
                             resourceSelector = {
                                 matchControllerRef = True
                             }
                         }
                     }
                 }
-                crossplaneapiextensionsv1alpha1.Usage{
+                crossplaneprotectionv1beta1.Usage{
                     metadata = {
                         name = "platform-ref-gcp-gke-by-oss"
                         labels = {
                             "crossplane.io/composite" = "platform-ref-gcp"
                         }
                         annotations = {
-                            "crossplane.io/composition-resource-name" = "usage-xgke-by-xoss"
+                            "crossplane.io/composition-resource-name" = "usage-gke-by-oss"
                         }
                     }
                     spec = {
                         replayDeletion = True
                         by = {
                             apiVersion = "observe.platform.upbound.io/v1alpha1"
-                            kind = "XOss"
+                            kind = "Oss"
                             resourceSelector = {
                                 matchControllerRef = True
                             }
                         }
                         of = {
                             apiVersion = "gcp.platform.upbound.io/v1alpha1"
-                            kind = "XGKE"
+                            kind = "GKE"
                             resourceSelector = {
                                 matchControllerRef = True
                             }
                         }
                     }
                 }
-                crossplaneapiextensionsv1alpha1.Usage{
+                crossplaneprotectionv1beta1.Usage{
                     metadata = {
                         name = "platform-ref-gcp-gke-by-labeled-release"
                         labels = {
@@ -207,7 +203,7 @@ _items = [
                         }
                         of = {
                             apiVersion = "gcp.platform.upbound.io/v1alpha1"
-                            kind = "XGKE"
+                            kind = "GKE"
                             resourceSelector = {
                                 matchControllerRef = True
                             }
@@ -215,10 +211,10 @@ _items = [
                     }
                 }
             ]
-            # Observed resources to simulate XGKE being ready (triggers XOss and XFlux creation)
+            # Observed resources to simulate GKE being ready (triggers Oss and Flux creation)
             observedResources = [
-                # XGKE with Ready condition to trigger XOss and XFlux creation
-                gcpv1alpha1.XGKE{
+                # GKE with Ready condition to trigger Oss and Flux creation
+                gcpv1alpha1.GKE{
                     metadata = {
                         name = "composite-cluster-gke"
                         annotations = {
@@ -229,17 +225,13 @@ _items = [
                         parameters = {
                             id = "platform-ref-gcp"
                             region = "us-west2"
-                            deletionPolicy = "Delete"
+                            managementPolicies = ["*"]
                             providerConfigName = "default"
                             version = "latest"
                             nodes = {
                                 count = 1
                                 instanceType = "n1-standard-4"
                             }
-                        }
-                        writeConnectionSecretToRef = {
-                            name = "test-uid-12345-gke"
-                            namespace = "upbound-system"
                         }
                     }
                     status = {

--- a/upbound.yaml
+++ b/upbound.yaml
@@ -22,11 +22,11 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gcp-gke
-    version: v2.0.2-rc1
+    version: v2.0.2
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gcp-database
-    version: v2.0.0
+    version: v2.1.0
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-app

--- a/upbound.yaml
+++ b/upbound.yaml
@@ -4,38 +4,41 @@ metadata:
   name: platform-ref-gcp
 spec:
   apiDependencies:
+  - k8s:
+      version: v1.33.0
+    type: k8s
   - git:
       path: cluster/crds
-      ref: release-1.20
+      ref: release-2.1
       repository: https://github.com/crossplane/crossplane
     type: crd
   crossplane:
-    version: '>=v1.20.0'
+    version: '>=v2.0.0'
   dependsOn:
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gcp-network
-    version: v0.9.0
+    version: v2.0.0
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gcp-gke
-    version: v0.11.1
+    version: v2.0.2-rc1
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gcp-database
-    version: v0.11.0
+    version: v2.0.0
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-app
-    version: v0.12.1
+    version: v2.1.0
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-observability-oss
-    version: v0.10.1
+    version: v2.0.0
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration
     package: xpkg.upbound.io/upbound/configuration-gitops-flux
-    version: v0.12.0
+    version: v2.0.0
   - apiVersion: pkg.crossplane.io/v1
     kind: Function
     package: xpkg.upbound.io/crossplane-contrib/function-auto-ready


### PR DESCRIPTION
## Summary

Full migration of platform-ref-gcp to Crossplane v2:

- **XRD**: `apiextensions.crossplane.io/v2`, `scope: Namespaced`, kind `Cluster` (no X-prefix), removed `claimNames` and `connectionSecretKeys`
- **Composition**: removed `compositeDeletePolicy` and `writeConnectionSecretToRef` (unsupported in v2)
- **Cluster function**: migrated `Usage` from `apiextensions.crossplane.io/v1alpha1` to `protection.crossplane.io/v1beta1` (namespaced, with `namespace = oxr.metadata.namespace`); removed `CompositeConnectionDetails`
- **upbound.yaml**: crossplane `>=v2.0.0`, added `k8s v1.33.0` apiDependency, CRD git ref → `release-2.1`, `configuration-gcp-gke` → `v2.0.2` (fixes provider channel conflicts)
- **Examples / e2e test**: rewritten to match typed-model pattern; added `helm.chart` fields for App; fixed MySQL connection secret name reference
- **Composition test**: updated to `protection.crossplane.io/v1beta1` Usage model



## Test plan

- [x] `up test run tests/test-cluster` passes
- [ ] E2E test (`up test run tests/e2etest-cluster --e2e`) — pending `configuration-gcp-database` PR #92 merge and release